### PR TITLE
Update mangalionz Url in MadaraGenerator.kt

### DIFF
--- a/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
+++ b/multisrc/src/main/java/eu/kanade/tachiyomi/multisrc/madara/MadaraGenerator.kt
@@ -274,7 +274,7 @@ class MadaraGenerator : ThemeSourceGenerator {
         SingleLang("MangaKitsune", "https://mangakitsune.com", "en", isNsfw = true, overrideVersionCode = 4),
         SingleLang("MangaKL", "https://mangakala.com", "ja"),
         SingleLang("MangaKomi", "https://mangakomi.io", "en", overrideVersionCode = 5),
-        SingleLang("MangaLionz", "https://mangalionz.com", "ar", overrideVersionCode = 1),
+        SingleLang("MangaLionz", "https://mangalionz.org", "ar", overrideVersionCode = 2),
         SingleLang("MangaManhua", "https://mangamanhua.online", "en", overrideVersionCode = 1),
         SingleLang("MangaManiacs", "https://mangamaniacs.org", "en", isNsfw = true),
         SingleLang("Manganelo.biz", "https://manganelo.biz", "en", isNsfw = true, className = "ManganeloBiz"),


### PR DESCRIPTION
updated  the source Url formangalionz from mangalionz.com to mangalionz.org

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
